### PR TITLE
DS-2570: remove original.subset and just use subset

### DIFF
--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -85,11 +85,7 @@ KMeans <- function(data = NULL,
         if (length(subset) > 1 & length(subset) != nrow(data))
             stop("'subset' and 'data' are required to have the same number of observations. They do not.")
         if (partial)
-        {
             subset <- CleanSubset(subset, n.total)
-            n.subset <- attr(subset, "n.subset")
-            original.subset <- subset
-        }
     }
     weighted <- !is.null(weights)
     if(weighted)
@@ -182,16 +178,10 @@ KMeans <- function(data = NULL,
     result$weights <- unfiltered.weights
     result$model <- data
     result$cluster <- cluster <- predict.KMeans(centers, data)
-    if (has.subset & (partial | weighted))
-    {
-        if (partial)
-            n <- sum(original.subset)
-    }
-    else
+    if (!(has.subset & (partial | weighted)))
         result$cluster[subset] <- model$cluster # This will often do nothing.
-    analysis.subset <- if(partial & has.subset) original.subset else subset
-    weights.a <- weights[analysis.subset]
-    data.a <- data[analysis.subset, , drop = FALSE]
+    weights.a <- weights[subset]
+    data.a <- data[subset, , drop = FALSE]
     result$sizes <- sizes <- Frequency(cluster.a, weights = weights.a)
     sizes <- as.numeric(prop.table(sizes))
     rownames(centers) <- paste0("Cluster ", 1:n.clusters, "\n", FormatAsPercent(sizes, 2))
@@ -202,7 +192,7 @@ KMeans <- function(data = NULL,
         result$centers <- MeanByGroup(data.a, cluster.a, weights.a)
     if (weighted)
     {   # Essentially an extra iteration
-        result$cluster[analysis.subset] <- clusters.a <- predict.KMeans(result$centers, data.a)
+        result$cluster[subset] <- clusters.a <- predict.KMeans(result$centers, data.a)
         result$centers <- MeanByGroup(data.a, clusters.a, weights.a)
     }
     result$cluster <- factor(cluster, levels = 1:n.clusters, labels = paste("Cluster", 1:n.clusters))

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -178,8 +178,6 @@ KMeans <- function(data = NULL,
     result$weights <- unfiltered.weights
     result$model <- data
     result$cluster <- cluster <- predict.KMeans(centers, data)
-    if (!(has.subset & (partial | weighted)))
-        result$cluster[subset] <- model$cluster # This will often do nothing.
     weights.a <- weights[subset]
     data.a <- data[subset, , drop = FALSE]
     result$sizes <- sizes <- Frequency(cluster.a, weights = weights.a)

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -1,0 +1,23 @@
+context("diagnostics")
+
+test_that("Kalinki Harabasz",{
+    set.seed(2)
+    clusters <- rep(1:3, c(20, 20, 20))
+    data <- data.frame(A = c(1, 2.1, 3)[clusters], B = 1)
+    km <- KMeans(data, 2)
+    # Tested against legacy Q cluster analysis
+    expect_equal(CalinskiHarabasz(data, km$centers, km$cluster)$Calinski.Harabasz, 229.4, tol = .1)
+
+    # By definition these are all 1
+    ext <- ExternalIndices(2, km$cluster, km$cluster)
+    expect_equal(ext$adjusted.rand, 1)
+    expect_equal(ext$Jaccard, 1)
+    expect_equal(ext$adjusted.rand, 1)
+
+    orthogonal <- rep(1:2, 30)
+    ext <- ExternalIndices(2, km$cluster, orthogonal)
+    expect_equal(ext$Fowlkes.Mallows, 0.5116257, tol = 0.00001)
+    expect_equal(ext$Jaccard, 0.3430657, tol = 0.00001)
+    expect_equal(ext$adjusted.rand, -0.0152963, tol = 0.00001) # Should be near 0
+
+})

--- a/tests/testthat/test-kmeans.R
+++ b/tests/testthat/test-kmeans.R
@@ -118,6 +118,16 @@ suppressWarnings(KMeans(data = dat, weights = wgt, show.labels = TRUE, centers =
 # Subset and weights
 suppressWarnings(KMeans(data = dat, subset = sb, weights = wgt, show.labels = TRUE, centers = 3))
 
+# Subset and weights with one weight equal to 0 (DS-2570)
+wgt2 <- wgt
+wgt2[2] <- 0
+suppressWarnings(KMeans(data = dat, subset = sb, weights = wgt2, show.labels = TRUE, centers = 3))
+
+# Subset with one row completely missing (DS-2570)
+dat2 <- dat
+dat2[2, ] <- NA
+suppressWarnings(KMeans(data = dat2, subset = sb, show.labels = TRUE, centers = 3))
+
 # Creating a data set with mean imputation
 meanDat <- as.data.frame(lapply(dat, unclass))
 mn <- matrix(apply(meanDat, 2, mean, na.rm = TRUE), byrow = TRUE, ncol = 25, nrow = nrow(meanDat))

--- a/tests/testthat/test-kmeans.R
+++ b/tests/testthat/test-kmeans.R
@@ -187,3 +187,24 @@ expect_equal(z2$cluster, z21$cluster)
 expect_true(!all(z$cluster == z2$cluster))
 
 })
+
+test_that("warnings and errors",{
+    set.seed(2)
+    clusters <- rep(1:3, c(20, 20, 20))
+    data <- data.frame(A = c(1, 2.1, 3)[clusters], B = 1)
+    # Warning and errors for bagging with small sample size
+    expect_error(suppressWarnings(KMeans(data, 2, algorithm = "Bagging")))
+    # Subset wrong size
+    expect_error(suppressWarnings(KMeans(data, 2, subset = rep(TRUE, 2))))
+    # Data set too small
+    expect_error(suppressWarnings(KMeans(data[1, , drop = FALSE], 2)))
+})
+
+test_that("Data provided as a list",{
+    set.seed(2)
+    clusters <- rep(1:3, c(20, 20, 20))
+    data <- list(a = data.frame(A = c(1, 2.1, 3)[clusters]), b = data.frame(B = rep(1, 60)))
+    attr(data[[1]], "questiontype") = "Number"
+    attr(data[[2]], "questiontype") = "Number"
+    expect_error(suppressWarnings(KMeans(data, 2)), NA)
+})

--- a/tests/testthat/test-simulateclusters.R
+++ b/tests/testthat/test-simulateclusters.R
@@ -1,0 +1,9 @@
+context("simulateclusters")
+
+
+test_that("smoke tests",{
+    expect_error(CreateSimulatedClusters(1, 3, 10, 100), NA)
+    expect_error(CreateSimulatedClusters(1, 5, 10, 100), NA)
+    dat <- CreateSimulatedClusters(1, 5, 10, 100)
+    expect_error(SimulateReliability(dat[[1]], .9), NA)
+})

--- a/tests/testthat/test-variables.R
+++ b/tests/testthat/test-variables.R
@@ -42,3 +42,19 @@ test_that("Missing data",
         })
 
 
+
+
+test_that("errors data",
+          {
+              data("consultant", package = "flipExampleData")
+              nms <- names(consultant)
+              dat <- consultant[, match("Q050__1", nms):match("Q050__25", nms) ]
+              attach(dat)
+              zd = data.frame(Q050__15, Q050__1, Q050__5, Q050__13, Q050__14, Q050__3, Q050__17, Q050__18, Q050__19, Q050__20, Q050__24)
+              z <- suppressWarnings(KMeans(zd, 2))
+              # Different dimensionality for newdata than data used to create clusters
+              expect_error(suppressWarnings(predict(z, newdata = zd[, -1])))
+              detach(dat)
+          })
+
+


### PR DESCRIPTION
I'm not sure why original.subset was used when missing = "Use partial
data" and a filter is provided (line 192 of the original code). The only
time original.subset differs from subset is when one of the weights is
zero or all values for a case are missing. When they do differ, a crash
occurs as we end up mixing vectors of different lengths, I have added
tests for these two cases, which used to fail but now pass with my
changes.

Please also check the line 
if (!(has.subset & (partial | weighted)))
    result$cluster[subset] <- model$cluster # This will often do nothing."
as the condition seems strange to me.